### PR TITLE
Add more manifest metadata

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,6 +2,8 @@
     "id": "com.mattermost.custom-attributes",
     "name": "Custom User Attributes",
     "description": "Add custom user attributes to the Mattermost user profile popover.",
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-custom-attributes",
+    "support_url": "https://github.com/mattermost/mattermost-plugin-custom-attributes/issues",
     "version": "1.1.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
Add `homepage_url` and `support_url` to the manifest. `support_url` is not jet used in the webapp, but there is no downside of defining it already.

I've tested the changes locally and can confirm that the link to the `homepage_url` is correctly shown.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21918
