### PR TITLE
MM-22719: resolve custom emoji in attributes

### DIFF
--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -1,3 +1,5 @@
+import {getCustomEmojisInText} from 'mattermost-redux/actions/emojis'
+
 import Client from '../client';
 import ActionTypes from '../action_types';
 import {id as pluginId} from '../manifest';
@@ -26,6 +28,8 @@ export function getAttributes(userID = '') {
             }
             return {error};
         }
+
+        (data || []).forEach((attribute) => dispatch(getCustomEmojisInText(attribute)));
 
         dispatch({
             type: ActionTypes.RECEIVED_ATTRIBUTES,

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -1,4 +1,4 @@
-import {getCustomEmojisInText} from 'mattermost-redux/actions/emojis'
+import {getCustomEmojisInText} from 'mattermost-redux/actions/emojis';
 
 import Client from '../client';
 import ActionTypes from '../action_types';

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -13,7 +13,7 @@ export function getAttributes(userID = '') {
             return {};
         }
 
-        let data;
+        let data = [];
         try {
             data = await Client.getAttributes(userID);
         } catch (error) {
@@ -29,7 +29,7 @@ export function getAttributes(userID = '') {
             return {error};
         }
 
-        (data || []).forEach((attribute) => dispatch(getCustomEmojisInText(attribute)));
+        data.forEach((attribute) => dispatch(getCustomEmojisInText(attribute)));
 
         dispatch({
             type: ActionTypes.RECEIVED_ATTRIBUTES,

--- a/webapp/src/components/admin_settings/custom_attribute/custom_attribute.jsx
+++ b/webapp/src/components/admin_settings/custom_attribute/custom_attribute.jsx
@@ -17,6 +17,7 @@ export default class CustomAttribute extends React.Component {
         onChange: PropTypes.func.isRequired,
         actions: PropTypes.shape({
             getProfilesByIds: PropTypes.func.isRequired,
+            getCustomEmojisInText: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -104,6 +105,8 @@ export default class CustomAttribute extends React.Component {
         if (!this.props.markdownPreview) {
             return null;
         }
+
+        this.props.actions.getCustomEmojisInText(this.state.name);
 
         const formattedText = formatText(this.state.name);
         return messageHtmlToComponent(formattedText);

--- a/webapp/src/components/admin_settings/custom_attribute/index.jsx
+++ b/webapp/src/components/admin_settings/custom_attribute/index.jsx
@@ -1,5 +1,6 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {getCustomEmojisInText} from 'mattermost-redux/actions/emojis'
 
 import {getProfilesByIds} from 'mattermost-redux/actions/users';
 
@@ -9,6 +10,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getProfilesByIds,
+            getCustomEmojisInText,
         }, dispatch),
     };
 }

--- a/webapp/src/components/admin_settings/custom_attribute/index.jsx
+++ b/webapp/src/components/admin_settings/custom_attribute/index.jsx
@@ -1,6 +1,6 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {getCustomEmojisInText} from 'mattermost-redux/actions/emojis'
+import {getCustomEmojisInText} from 'mattermost-redux/actions/emojis';
 
 import {getProfilesByIds} from 'mattermost-redux/actions/users';
 


### PR DESCRIPTION
#### Summary
Resolve any custom emoji in attributes. Typically, these custom emoji are resolved organically when they appear for the first time in posts, but if not, we now rely on mattermost-redux to ensure same.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-22719
