### PR TITLE
[GH-37] Hide Custom Attributes if Post is from Webhook

### DIFF
--- a/webapp/src/components/user_attribute/index.js
+++ b/webapp/src/components/user_attribute/index.js
@@ -11,6 +11,7 @@ const REDUCER = `plugins-${pluginId}`;
 function mapStateToProps(state, ownProps) {
     const id = ownProps.user ? ownProps.user.id : '';
     const data = state[REDUCER].attributes[id];
+    const fromWebhook = ownProps.overwriteName && ownProps.overwriteIcon;
     let attributes;
     if (data) {
         attributes = data.attributes;
@@ -19,6 +20,7 @@ function mapStateToProps(state, ownProps) {
     return {
         id,
         attributes,
+        fromWebhook,
     };
 }
 

--- a/webapp/src/components/user_attribute/user_attribute.jsx
+++ b/webapp/src/components/user_attribute/user_attribute.jsx
@@ -8,6 +8,7 @@ const {formatText, messageHtmlToComponent} = window.PostUtils;
 export default class UserAttribute extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string.isRequired,
+        fromWebhook: PropTypes.bool.isRequired,
         attributes: PropTypes.arrayOf(PropTypes.string),
         actions: PropTypes.shape({
             getAttributes: PropTypes.func.isRequired,
@@ -23,9 +24,9 @@ export default class UserAttribute extends React.PureComponent {
     }
 
     render() {
-        const {attributes} = this.props;
+        const {attributes, fromWebhook} = this.props;
 
-        if (attributes == null || attributes.length === 0) {
+        if (fromWebhook || attributes == null || attributes.length === 0) {
             return null;
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Skips rendering of custom attributes to the DOM if the post has it's icon and name overwritten.

#### Ticket Link

Fixes #37.

