### PR TITLE
fix issues with using an outdated redux package

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "core-js": "3.1.4",
     "lodash": "^4.17.19",
-    "mattermost-redux": "5.26.0",
+    "mattermost-redux": "5.33.0",
     "react": "16.4.1",
     "react-dom": "^16.12.0",
     "react-redux": "5.0.7",


### PR DESCRIPTION
#### Summary

#68 - Fix to resolve the outdated redux package. Specifically for `searchTeams`. Tested locally and there are no errors.

The plugin is currently built to take `searchTeams(term, options)` however the version of redux 5.26 doesn't take that. It looks like previously it took `export function searchTeams(term: string, page?: number, perPage?: number)` https://github.com/mattermost/mattermost-redux/commit/106c35967b1a92140fc86dfb442d88520c070643

5.33 redux `searchTeams` - https://github.com/mattermost/mattermost-redux/blob/3d1028034d7677adfda58e91b9a5dcaf1bc0ff99/src/actions/teams.ts#L142

#### Recreate
1. Git clone the current repo
2. run `make dist`
3. Upload the plugin to your server
4. Attempt to search teams and you'll see the 404 error



