### PR TITLE
Fixes #67. Replaced empty string with empty array

### DIFF
--- a/webapp/src/components/admin_settings/custom_attribute_settings.jsx
+++ b/webapp/src/components/admin_settings/custom_attribute_settings.jsx
@@ -108,7 +108,7 @@ export default class CustomAttributesSettings extends React.Component {
             Name: name,
             UserIDs: userIds,
             TeamIDs: teamIds,
-            GroupIDs: groups ? groups.split(' ') : '',
+            GroupIDs: groups ? groups.split(' ') : [],
         });
 
         this.props.onChange(this.props.id, Array.from(this.state.attributes.values()));


### PR DESCRIPTION
Fixes #67.

Just replaced the empty string with an empty array. Tested and the config.json file saves / parses properly on restarting mattermost.